### PR TITLE
fix: replace deprecated SQLAlchemy legacy query API with 2.x style

### DIFF
--- a/budget/calc.py
+++ b/budget/calc.py
@@ -1,5 +1,5 @@
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy import case, func
+from sqlalchemy import case, func, select
 
 # local
 from budget.models import db, Income, Expense, Investments, Withholdings, Assets
@@ -65,15 +65,15 @@ class Sums():
         try:
             match table_name:
                 case "expenses":
-                    return Expense.query.with_entities(func.sum(Expense.amount * Sums.get_frequency_case(Expense))).scalar() or 0
+                    return db.session.execute(select(func.sum(Expense.amount * Sums.get_frequency_case(Expense)))).scalar() or 0
                 case "incomes":
-                    return Income.query.with_entities(func.sum(Income.amount * Sums.get_frequency_case(Income))).scalar() or 0
+                    return db.session.execute(select(func.sum(Income.amount * Sums.get_frequency_case(Income)))).scalar() or 0
                 case "investments":
-                    return Investments.query.with_entities(func.sum(Investments.amount)).scalar() or 0
+                    return db.session.execute(select(func.sum(Investments.amount))).scalar() or 0
                 case "assets":
-                    return Assets.query.with_entities(func.sum(Assets.amount)).scalar() or 0
+                    return db.session.execute(select(func.sum(Assets.amount))).scalar() or 0
                 case "withholdings":
-                    return Withholdings.query.with_entities(func.sum(Withholdings.amount * Sums.get_frequency_case(Withholdings))).scalar() or 0
+                    return db.session.execute(select(func.sum(Withholdings.amount * Sums.get_frequency_case(Withholdings)))).scalar() or 0
         except SQLAlchemyError as e:
             db.session.rollback()
             # log error and/or notify

--- a/budget/routes.py
+++ b/budget/routes.py
@@ -27,7 +27,7 @@ def overview():
     processes = [Income, Expense, Investments, Withholdings, Assets]
 
     for process in processes:
-        records = process.query.all()
+        records = db.session.execute(db.select(process)).scalars().all()
         formatted_records = []
 
         for record in records:

--- a/budget/routes.py
+++ b/budget/routes.py
@@ -3,8 +3,7 @@ import logging
 from flask import Blueprint, current_app, render_template, jsonify, request
 
 # Local imports
-# from .__init__ import db
-from .models import Income, Expense, Investments, Withholdings, Assets
+from .models import db, Income, Expense, Investments, Withholdings, Assets
 from .calc import Functions, Sums, Reports
 
 logging.basicConfig(filename='error.log', level=logging.ERROR)
@@ -70,15 +69,15 @@ def edit_item(id):
     process = data.get('type')
     match process:
         case "expense":
-            item = Expense.query.get(id)
+            item = db.session.get(Expense, id)
         case "income":
-            item = Income.query.get(id)
+            item = db.session.get(Income, id)
         case "investment":
-            item = Investments.query.get(id)
+            item = db.session.get(Investments, id)
         case "asset":
-            item = Assets.query.get(id)
+            item = db.session.get(Assets, id)
         case "withholding":
-            item = Withholdings.query.get(id)
+            item = db.session.get(Withholdings, id)
     
     # Update the db
     item.description = data['description']
@@ -93,15 +92,15 @@ def delete_item(id):
     data = request.get_json()
     match data.get('type'):
         case "expense":
-            Functions.delete(Expense.query.get(id))
+            Functions.delete(db.session.get(Expense, id))
         case "income":
-            Functions.delete(Income.query.get(id))
+            Functions.delete(db.session.get(Income, id))
         case "investment":
-            Functions.delete(Investments.query.get(id))
+            Functions.delete(db.session.get(Investments, id))
         case "asset":
-            Functions.delete(Assets.query.get(id))
+            Functions.delete(db.session.get(Assets, id))
         case "withholding":
-            Functions.delete(Withholdings.query.get(id))
+            Functions.delete(db.session.get(Withholdings, id))
     return jsonify({"message": "${process} deleted"}), 200
 
 


### PR DESCRIPTION
## Summary
Replaces deprecated SQLAlchemy legacy query patterns with modern 2.x equivalents.

### Changes
**routes.py**
- Uncommented `db` import from models
- Replaced `Model.query.get(id)` with `db.session.get(Model, id)` in `edit_item` and `delete_item`
- Replaced `Model.query.all()` with `db.session.execute(db.select(Model)).scalars().all()` in `overview`

**calc.py**
- Added `select` to SQLAlchemy imports
- Replaced `Model.query.with_entities()` with `db.session.execute(select(...))` in all `Sums.total()` cases

No logic changes — purely modernizing the query API.